### PR TITLE
fix: stop handler cycle on stack change

### DIFF
--- a/lib/Context/cycleHandler.ts
+++ b/lib/Context/cycleHandler.ts
@@ -9,6 +9,7 @@ const HANDLER_OVERFLOW = 400;
 
 const cycleHandler = async (context: Context, diagram: Diagram, variableState: Storage): Promise<void> => {
   const referenceFrame = context.stack.top();
+  const currentFrames = context.stack.getFrames();
 
   let nextID: string | null = null;
   let i = 0;
@@ -28,7 +29,6 @@ const cycleHandler = async (context: Context, diagram: Diagram, variableState: S
       const _block = block; // resolve TS type
 
       try {
-        // eslint-disable-next-line no-loop-func
         const handler = context.getHandlers().find((h) => h.canHandle(_block, context, variableState, diagram));
 
         if (handler) {
@@ -47,7 +47,8 @@ const cycleHandler = async (context: Context, diagram: Diagram, variableState: S
         context.end();
       }
 
-      if (!nextID || context.hasEnded()) {
+      // exit conditions for handler loop
+      if (!nextID || context.hasEnded() || currentFrames !== context.stack.getFrames()) {
         block = null;
       }
     }


### PR DESCRIPTION
so if any handler decides to actually modify the stack (popping, pushing, etc) - the current `cycleHandler` loop becomes absolutely irrelevant and should exit immediately

Since the handler loop is meant to loop through one particular Diagram/Frame

Presently I believe only the command block, end block, flow block do this - by logic obviously they should all exit out of their current loop anyways so this is an additional safety measure, so that we don't get nextIDs that irrelevant