### PR TITLE
fix: override math ops with custom methods

### DIFF
--- a/lib/Handlers/utils/mathJsWorker.ts
+++ b/lib/Handlers/utils/mathJsWorker.ts
@@ -26,6 +26,30 @@ math.import!(
       throw new Error('Function derivative is disabled');
     },
     // end of security fix
+
+    // override native methods
+    add: (x: any, y: any) => x + y,
+    subtract: (x: any, y: any) => x - y,
+    multiply: (x: any, y: any) => x * y,
+    divide: (x: any, y: any) => x / y,
+
+    equal: (x: any, y: any) => x == y, // eslint-disable-line eqeqeq
+    or: (x: any, y: any) => x || y,
+    and: (x: any, y: any) => x && y,
+    not: (x: any) => !x,
+
+    pow: (x: any, y: any) => x ** y,
+    compare: (x: any, y: any) => {
+      // eslint-disable-next-line eqeqeq
+      if (x == y) {
+        return 0;
+      }
+      if (x > y) {
+        return 1;
+      }
+
+      return -1;
+    },
   },
   { override: true }
 );


### PR DESCRIPTION
old server overrides these methods in the mathjs library, so I'm keeping the behaviour consistent in the new server as well. Reasoning that users are using of it.

Ex. Nico's test project has a set block with an expression of 'Voice' + 'flow'. Native mathjs add parses the operands so it throws an error cause "Cannot convert "Voice" to a number". While our override doesn't parse so it yields the result of 'Voiceflow'

