### PR TITLE
fix: expression eval timeout

### DIFF
--- a/lib/Handlers/utils/shuntingYard.ts
+++ b/lib/Handlers/utils/shuntingYard.ts
@@ -7,7 +7,7 @@ const evalExpression = async (expression: string, variables: Record<string, any>
   // start js script as dedicated worker
   const mathJsWorkerPool = workerpool.pool(`${__dirname}/mathJsWorker.js`, { maxWorkers: 1 });
   // evaluate expressions in a separate worker to prevent memory overflow of main thread
-  const result = await mathJsWorkerPool.exec('evaluate', [exp, variables]).timeout(650);
+  const result = await mathJsWorkerPool.exec('evaluate', [exp, variables]).timeout(1000);
   await mathJsWorkerPool.terminate();
 
   return result;


### PR DESCRIPTION
long enough to run expressions. not long enough for expressions like `zeros(1000000000, 1000000000)` to make the service run out of memory