### PR TITLE
fix: reset block

### DIFF
--- a/lib/Context/Stack/Frame/index.ts
+++ b/lib/Context/Stack/Frame/index.ts
@@ -82,7 +82,7 @@ class Frame {
     return this.nodeID;
   }
 
-  public setNodeID(nodeID: string | null): void {
+  public setNodeID(nodeID?: string | null): void {
     this.nodeID = nodeID;
   }
 

--- a/lib/Handlers/reset.ts
+++ b/lib/Handlers/reset.ts
@@ -11,7 +11,7 @@ const ResetHandler: HandlerFactory<ResetNode> = () => ({
   canHandle: (node) => !!node.reset,
   handle: (_, context) => {
     context.stack.popTo(1);
-    context.stack.top().setNodeID(null);
+    context.stack.top().setNodeID(undefined);
 
     return null;
   },

--- a/tests/lib/Handlers/reset.unit.ts
+++ b/tests/lib/Handlers/reset.unit.ts
@@ -41,7 +41,7 @@ describe('reset handler unit tests', async () => {
 
       expect(resetHandler.handle(null as any, context as any, null as any, null as any)).to.eql(null);
       expect(context.stack.popTo.args).to.eql([[1]]);
-      expect(topFrame.setNodeID.args).to.eql([[null]]);
+      expect(topFrame.setNodeID.args).to.eql([[undefined]]);
     });
   });
 });


### PR DESCRIPTION
[JIRA LINK](https://voiceflow.atlassian.net/browse/CORE-4518)

this is a really weird issue because I have to assume it's always been broken for awhile now?

right now in `Stack/Frame` it only resets the frame's nodeID to the start block if the frame's nodeID is `undefined`, it will not work if it is `null`, and I'm a bit scared to change it to accept `null` because of side effects.
https://github.com/voiceflow/runtime/blob/ed387b206c70f686a5a57032adc63cd57c6a8ab3/lib/Context/Stack/Frame/index.ts#L76-L78

so my solution is in the reset block make the frame's node undefined to trigger it restarting from the beginning again