### PR TITLE
fix: instantiating null to undefined

### DIFF
--- a/lib/Context/Stack/Frame/index.ts
+++ b/lib/Context/Stack/Frame/index.ts
@@ -42,8 +42,10 @@ class Frame {
   public variables: Store;
 
   constructor(frameState: Options) {
-    this.nodeID = frameState.nodeID ?? frameState.blockID;
-    this.programID = frameState.programID ?? frameState.diagramID;
+    if (frameState.hasOwnProperty('blockID')) this.nodeID = frameState.blockID;
+    if (frameState.hasOwnProperty('nodeID')) this.nodeID = frameState.nodeID;
+
+    this.programID = frameState.diagramID ?? frameState.programID;
 
     this.storage = new Store(frameState.storage);
     this.commands = frameState.commands ?? [];


### PR DESCRIPTION
so the problem here was that we have very big differences in how `null` and `undefined` are handled. `undefined` means we restart the flow from the beginning, `null` means we end the flow.

So the problem is here is because we switched to the new format, using `nodeID` instead of `blockID` - we were doing `null ?? undefined` which equals `undefined` when it should be `null`