### PR TITLE
feat: always return trace

### DIFF
--- a/lib/Context/Trace/index.ts
+++ b/lib/Context/Trace/index.ts
@@ -24,7 +24,7 @@ export default class Trace {
     this.traces = [...this.traces, frame];
   }
 
-  get<TF extends TraceFrame>(): TF[] {
+  getState<TF extends TraceFrame>(): TF[] {
     return this.traces as TF[];
   }
 

--- a/lib/Context/Trace/index.ts
+++ b/lib/Context/Trace/index.ts
@@ -5,7 +5,7 @@ import { EventType } from '@/lib/Lifecycle';
 import Context from '..';
 
 export default class Trace {
-  private trace: TraceFrame[] = [];
+  private traces: TraceFrame[] = [];
 
   constructor(private context: Context) {}
 
@@ -21,11 +21,11 @@ export default class Trace {
 
     if (stop) return;
 
-    this.trace = [...this.trace, frame];
+    this.traces = [...this.traces, frame];
   }
 
   get<TF extends TraceFrame>(): TF[] {
-    return this.trace as TF[];
+    return this.traces as TF[];
   }
 
   debug(message: string) {

--- a/lib/Context/index.ts
+++ b/lib/Context/index.ts
@@ -1,3 +1,5 @@
+import { TraceFrame } from '@voiceflow/general-types';
+
 import cycleStack from '@/lib/Context/cycleStack';
 import Handler from '@/lib/Handler';
 import Lifecycle, { AbstractLifecycle, Event, EventType } from '@/lib/Lifecycle';
@@ -20,6 +22,7 @@ export interface State {
   stack: FrameState[];
   storage: StorageState;
   variables: StorageState;
+  trace: TraceFrame[];
 }
 
 export enum Action {
@@ -137,7 +140,7 @@ class Context<DA extends DataAPI = DataAPI> extends AbstractLifecycle {
     }
   }
 
-  public getFinalState(): State {
+  public getFinalState(): Omit<State, 'turn'> {
     if (this.action === Action.IDLE) {
       throw new Error('context not updated');
     }
@@ -146,6 +149,7 @@ class Context<DA extends DataAPI = DataAPI> extends AbstractLifecycle {
       stack: this.stack.getState(),
       storage: this.storage.getState(),
       variables: this.variables.getState(),
+      trace: this.trace.get(),
     };
   }
 
@@ -155,6 +159,7 @@ class Context<DA extends DataAPI = DataAPI> extends AbstractLifecycle {
       stack: this.stack.getState(),
       storage: this.storage.getState(),
       variables: this.variables.getState(),
+      trace: this.trace.get(),
     };
   }
 

--- a/lib/Context/index.ts
+++ b/lib/Context/index.ts
@@ -149,7 +149,7 @@ class Context<DA extends DataAPI = DataAPI> extends AbstractLifecycle {
       stack: this.stack.getState(),
       storage: this.storage.getState(),
       variables: this.variables.getState(),
-      trace: this.trace.get(),
+      trace: this.trace.getState(),
     };
   }
 
@@ -159,7 +159,7 @@ class Context<DA extends DataAPI = DataAPI> extends AbstractLifecycle {
       stack: this.stack.getState(),
       storage: this.storage.getState(),
       variables: this.variables.getState(),
-      trace: this.trace.get(),
+      trace: this.trace.getState(),
     };
   }
 

--- a/tests/lib/Context/Trace/index.unit.ts
+++ b/tests/lib/Context/Trace/index.unit.ts
@@ -15,7 +15,7 @@ describe('Context Trace unit tests', () => {
       const frame = { foo: 'bar' };
       trace.addTrace(frame as any);
 
-      expect(_.get(trace, 'trace')).to.eql([frame]);
+      expect(_.get(trace, 'traces')).to.eql([frame]);
       expect(context.callEvent.callCount).to.eql(1);
       expect(context.callEvent.args[0][0]).to.eql(EventType.traceWillAdd);
       expect(context.callEvent.args[0][1].frame).to.eql(frame);
@@ -32,14 +32,14 @@ describe('Context Trace unit tests', () => {
       const trace = new Trace(context as any);
       trace.addTrace({ foo: 'bar' } as any);
 
-      expect(_.get(trace, 'trace')).to.eql([]);
+      expect(_.get(trace, 'traces')).to.eql([]);
     });
   });
 
   it('get', () => {
     const traceObj = new Trace(null as any);
     const trace = [{}, {}];
-    _.set(traceObj, 'trace', trace);
-    expect(traceObj.get()).to.eql(trace);
+    _.set(traceObj, 'traces', trace);
+    expect(traceObj.getState()).to.eql(trace);
   });
 });

--- a/tests/lib/Context/index.unit.ts
+++ b/tests/lib/Context/index.unit.ts
@@ -75,7 +75,7 @@ describe('Context unit', () => {
 
   it('getRawState', () => {
     const context = new Context(null as any, { stack: [] } as any, undefined as any, {} as any, null as any);
-    expect(context.getRawState()).to.eql({ turn: {}, stack: [], storage: {}, variables: {} });
+    expect(context.getRawState()).to.eql({ turn: {}, stack: [], storage: {}, variables: {}, trace: [] });
   });
 
   describe('getFinalState', () => {
@@ -89,7 +89,7 @@ describe('Context unit', () => {
     it('returns', () => {
       const context = new Context(null as any, { stack: [] } as any, undefined as any, {} as any, null as any);
       context.setAction(Action.END);
-      expect(context.getFinalState()).to.eql({ stack: [], storage: {}, variables: {} });
+      expect(context.getFinalState()).to.eql({ stack: [], storage: {}, variables: {}, trace: [] });
     });
   });
 


### PR DESCRIPTION
I don't think `alexa-runtime` or `google-runtime` use trace in any meaningful way