### PR TITLE
feat: request response model

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 export { default as Frame } from '@/lib/Runtime/Stack/Frame';
 export { default as Stack } from '@/lib/Runtime/Stack';
 export { default as Store } from '@/lib/Runtime/Store';
-export { default as Runtime, State } from '@/lib/Runtime';
+export { default as Runtime, State, Action } from '@/lib/Runtime';
 export { default as Handler, HandlerFactory } from '@/lib/Handler';
 export { default as Program } from '@/lib/Program';
 export { EventType, Event, EventCallback, CallbackEvent } from '@/lib/Lifecycle';

--- a/lib/Client/index.ts
+++ b/lib/Client/index.ts
@@ -2,7 +2,7 @@ import { DataAPI } from '@/lib/DataAPI';
 import { AbstractLifecycle } from '@/lib/Lifecycle';
 import Runtime, { Options as RuntimeOptions, State as RuntimeState } from '@/lib/Runtime';
 
-class Controller<I extends any = any, D extends DataAPI = DataAPI> extends AbstractLifecycle {
+class Controller<R extends any = any, D extends DataAPI = DataAPI> extends AbstractLifecycle {
   private options: Pick<RuntimeOptions<D>, 'api' | 'handlers' | 'services'>;
 
   constructor({ api, handlers = [], services = {} }: RuntimeOptions<D>) {
@@ -15,8 +15,8 @@ class Controller<I extends any = any, D extends DataAPI = DataAPI> extends Abstr
     };
   }
 
-  public createRuntime(versionID: string, state: RuntimeState, input?: I, options?: RuntimeOptions<D>): Runtime<I, D> {
-    return new Runtime<I, D>(versionID, state, input, { ...this.options, ...options }, this.events);
+  public createRuntime(versionID: string, state: RuntimeState, request?: R, options?: RuntimeOptions<D>): Runtime<R, D> {
+    return new Runtime<R, D>(versionID, state, request, { ...this.options, ...options }, this.events);
   }
 }
 

--- a/lib/Client/index.ts
+++ b/lib/Client/index.ts
@@ -2,7 +2,7 @@ import { DataAPI } from '@/lib/DataAPI';
 import { AbstractLifecycle } from '@/lib/Lifecycle';
 import Runtime, { Options as RuntimeOptions, State as RuntimeState } from '@/lib/Runtime';
 
-class Controller<I extends Record<string, unknown> = Record<string, unknown>, D extends DataAPI = DataAPI> extends AbstractLifecycle {
+class Controller<I extends any = any, D extends DataAPI = DataAPI> extends AbstractLifecycle {
   private options: Pick<RuntimeOptions<D>, 'api' | 'handlers' | 'services'>;
 
   constructor({ api, handlers = [], services = {} }: RuntimeOptions<D>) {

--- a/lib/Handler/index.ts
+++ b/lib/Handler/index.ts
@@ -4,7 +4,7 @@ import Program from '@/lib/Program';
 import Runtime from '@/lib/Runtime';
 import Store from '@/lib/Runtime/Store';
 
-export default interface Handler<N extends Node = Node<any, any>, R extends Record<string, unknown> = Record<string, unknown>> {
+export default interface Handler<N extends Node = Node<any, any>, R extends any = any> {
   canHandle: (node: N, runtime: Runtime<R>, variables: Store, program: Program) => boolean;
   handle: (node: N, runtime: Runtime<R>, variables: Store, program: Program) => null | string | Promise<string | null>;
 }

--- a/lib/Runtime/index.ts
+++ b/lib/Runtime/index.ts
@@ -23,11 +23,12 @@ export interface State {
 
 export enum Action {
   IDLE,
-  RUNNING,
+  REQUEST,
+  RESPONSE,
   END,
 }
 
-class Runtime<R extends Record<string, unknown> = Record<string, unknown>, DA extends DataAPI = DataAPI> extends AbstractLifecycle {
+class Runtime<R extends any = any, DA extends DataAPI = DataAPI> extends AbstractLifecycle {
   public turn: Store;
 
   public stack: Stack;
@@ -91,10 +92,6 @@ class Runtime<R extends Record<string, unknown> = Record<string, unknown>, DA ex
     this.programManager = new ProgramManager(this);
   }
 
-  setRequest(request: R) {
-    this.request = request;
-  }
-
   getRequest(): R | null {
     return this.request;
   }
@@ -131,7 +128,7 @@ class Runtime<R extends Record<string, unknown> = Record<string, unknown>, DA ex
         throw new Error('runtime updated twice');
       }
 
-      this.setAction(Action.RUNNING);
+      this.setAction(this.request ? Action.REQUEST : Action.RESPONSE);
       await cycleStack(this);
 
       await this.callEvent(EventType.updateDidExecute, {});

--- a/tests/lib/Runtime/index.unit.ts
+++ b/tests/lib/Runtime/index.unit.ts
@@ -107,9 +107,25 @@ describe('Runtime unit', () => {
       expect(callEventStub.args[1][1].error.message).to.eql('runtime updated twice');
     });
 
-    it('is idle', async () => {
+    it('response action', async () => {
       const cycleStackStub = sinon.stub(cycleStack, 'default');
       const runtime = new Runtime(null as any, { stack: [] } as any, undefined as any, {} as any, null as any);
+      const callEventStub = sinon.stub();
+      runtime.callEvent = callEventStub;
+      const setActionStub = sinon.stub();
+      runtime.setAction = setActionStub;
+      await runtime.update();
+      expect(callEventStub.args).to.eql([
+        [EventType.updateWillExecute, {}],
+        [EventType.updateDidExecute, {}],
+      ]);
+      expect(setActionStub.args).to.eql([[Action.RESPONSE]]);
+      expect(cycleStackStub.args).to.eql([[runtime]]);
+    });
+
+    it('request action', async () => {
+      const cycleStackStub = sinon.stub(cycleStack, 'default');
+      const runtime = new Runtime(null as any, { stack: [] } as any, true as any, {} as any, null as any);
       const callEventStub = sinon.stub();
       runtime.callEvent = callEventStub;
       const setActionStub = sinon.stub();

--- a/tests/lib/Runtime/index.unit.ts
+++ b/tests/lib/Runtime/index.unit.ts
@@ -25,23 +25,16 @@ describe('Runtime unit', () => {
     expect(runtime.getRequest()).to.eql(input);
   });
 
-  it('setRequest', () => {
-    const input = { type: 'req', payload: {} };
-    const runtime = new Runtime(null as any, { stack: [] } as any, 'oldInput' as any, {} as any, null as any);
-    expect(runtime.setRequest(input)).to.eq(undefined);
-    expect(runtime.getRequest()).to.eql(input);
-  });
-
   it('setAction', () => {
     const runtime = new Runtime(null as any, { stack: [] } as any, undefined as any, {} as any, null as any);
-    const action = Action.RUNNING;
+    const action = Action.RESPONSE;
     runtime.setAction(action as any);
     expect(_.get(runtime, 'action')).to.eql(action);
   });
 
   it('getAction', () => {
     const runtime = new Runtime(null as any, { stack: [] } as any, undefined as any, {} as any, null as any);
-    const action = Action.RUNNING;
+    const action = Action.RESPONSE;
     runtime.setAction(action as any);
     expect(runtime.getAction()).to.eql(action);
   });
@@ -103,7 +96,7 @@ describe('Runtime unit', () => {
   describe('update', () => {
     it('catch error', async () => {
       const runtime = new Runtime(null as any, { stack: [] } as any, undefined as any, {} as any, null as any);
-      runtime.setAction(Action.RUNNING);
+      runtime.setAction(Action.REQUEST);
       const callEventStub = sinon.stub().resolves();
       runtime.callEvent = callEventStub;
       await runtime.update();
@@ -126,7 +119,7 @@ describe('Runtime unit', () => {
         [EventType.updateWillExecute, {}],
         [EventType.updateDidExecute, {}],
       ]);
-      expect(setActionStub.args).to.eql([[Action.RUNNING]]);
+      expect(setActionStub.args).to.eql([[Action.REQUEST]]);
       expect(cycleStackStub.args).to.eql([[runtime]]);
     });
   });


### PR DESCRIPTION
in all our runtimes, we were using the `TURN` storage 
`const request = runtime.turn.get<IntentRequest>(TurnType.REQUEST)` as a flag for whether or not a request has been handled so the interaction block knows whether to process the result or wait for user response. Instead going to have this built into the runtime model

the current action the runtime is in goes from `IDLE` -> `REQUEST` (handle request) -> `RESPONSE`
this should be built into the runtime since it is pretty essential for handling user interaction.