### PR TITLE
fix: turn resolve

### DIFF
--- a/lib/Context/index.ts
+++ b/lib/Context/index.ts
@@ -38,4 +38,14 @@ export class TurnBuilder<C extends Context<any, any, any>> extends ContextBuilde
   async handle(_request: PartialContext<C>) {
     return super.handle(await this.init.handle(_request));
   }
+
+  async resolve(_request: PartialContext<C>) {
+    const { request, state, trace } = await this.handle(_request);
+
+    return {
+      request,
+      state,
+      trace,
+    };
+  }
 }


### PR DESCRIPTION
ensure the response only sends back `request`, `trace`, and `state` - don't need any extra data to confuse the users
![Screen Shot 2021-01-22 at 10 15 55 AM](https://user-images.githubusercontent.com/5643574/105508957-fcbe9700-5c9a-11eb-8208-0575eac314af.png)
