### PR TITLE
feat: API Key Verification (CORE-5221)

### DIFF
--- a/lib/DataAPI/creatorDataAPI.ts
+++ b/lib/DataAPI/creatorDataAPI.ts
@@ -15,12 +15,12 @@ class CreatorDataAPI<P extends Program<any, any>, V extends Version<any>, PJ ext
   constructor(
     {
       endpoint,
-      authorization,
+      authorization = '',
       clientKey = '',
       prototype = true,
     }: {
       endpoint: string;
-      authorization: string;
+      authorization?: string;
       clientKey?: string;
       prototype?: boolean;
     },
@@ -37,8 +37,8 @@ class CreatorDataAPI<P extends Program<any, any>, V extends Version<any>, PJ ext
     // no-op
   };
 
-  public updateAuthorization = (authorization: string) => {
-    this.client = this.vfClient.generateClient({ authorization: authorization || this.initialAuth });
+  public updateAuthorization = (authorization?: string) => {
+    this.client = this.vfClient.generateClient({ authorization: authorization ?? this.initialAuth });
   };
 
   public fetchDisplayById = async (): Promise<null> => {

--- a/lib/DataAPI/creatorDataAPI.ts
+++ b/lib/DataAPI/creatorDataAPI.ts
@@ -6,6 +6,10 @@ class CreatorDataAPI<P extends Program<any, any>, V extends Version<any>, PJ ext
   implements DataAPI<P, V, PJ> {
   protected client: Client;
 
+  protected vfClient: Voiceflow;
+
+  protected initialAuth: string;
+
   private prototype: boolean;
 
   constructor(
@@ -22,13 +26,19 @@ class CreatorDataAPI<P extends Program<any, any>, V extends Version<any>, PJ ext
     },
     VFClient = Voiceflow
   ) {
-    this.client = new VFClient({ apiEndpoint: endpoint, clientKey }).generateClient({ authorization });
+    this.vfClient = new VFClient({ apiEndpoint: endpoint, clientKey });
+    this.initialAuth = authorization;
+    this.client = this.vfClient.generateClient({ authorization });
 
     this.prototype = prototype;
   }
 
   public init = async () => {
     // no-op
+  };
+
+  public updateAuthorization = (authorization: string) => {
+    this.client = this.vfClient.generateClient({ authorization: authorization || this.initialAuth });
   };
 
   public fetchDisplayById = async (): Promise<null> => {

--- a/tests/lib/DataAPI/creatorDataAPI.unit.ts
+++ b/tests/lib/DataAPI/creatorDataAPI.unit.ts
@@ -9,10 +9,10 @@ describe('creatorDataAPI client unit tests', () => {
   });
 
   describe('new', () => {
-    it('works correctly', async () => {
-      const VFClient = sinon.stub();
+    it('constructor works correctly', async () => {
+      const generateClientStub = sinon.stub();
       const VF = sinon.stub().returns({
-        generateClient: VFClient,
+        generateClient: generateClientStub,
       });
 
       const config = { endpoint: '_endpoint', authorization: '_authorization', clientKey: '_clientKey', prototype: true };
@@ -21,15 +21,30 @@ describe('creatorDataAPI client unit tests', () => {
       await creatorDataAPI.init();
 
       expect(VF.args).to.eql([[{ apiEndpoint: config.endpoint, clientKey: config.clientKey }]]);
-      expect(VFClient.args).to.eql([[{ authorization: config.authorization }]]);
+      expect(generateClientStub.args).to.eql([[{ authorization: config.authorization }]]);
     });
+  });
+
+  it('updateAuthorization', () => {
+    const generateClientStub = sinon.stub();
+    const VF = sinon.stub().returns({
+      generateClient: generateClientStub,
+    });
+
+    const config = { endpoint: '_endpoint', authorization: '_authorization', clientKey: '_clientKey', prototype: true };
+
+    const creatorDataAPI = new CreatorDataAPI(config, VF as any);
+    creatorDataAPI.updateAuthorization('new auth');
+
+    expect(generateClientStub.firstCall.args).to.eql([{ authorization: config.authorization }]);
+    expect(generateClientStub.secondCall.args).to.eql([{ authorization: 'new auth' }]);
   });
 
   describe('fetchDisplayById', () => {
     it('no data', async () => {
-      const VFClient = sinon.stub();
+      const generateClientStub = sinon.stub();
       const VF = sinon.stub().returns({
-        generateClient: VFClient,
+        generateClient: generateClientStub,
       });
 
       const config = { endpoint: '_endpoint', authorization: '_authorization', clientKey: '_clientKey', prototype: true };
@@ -44,9 +59,9 @@ describe('creatorDataAPI client unit tests', () => {
       const programID = 'programID';
       const program = 'program';
       const Client = { program: { get: sinon.stub().resolves(program) }, prototypeProgram: { get: sinon.stub().resolves(program) } };
-      const VFClient = sinon.stub().returns(Client);
+      const generateClientStub = sinon.stub().returns(Client);
       const VF = sinon.stub().returns({
-        generateClient: VFClient,
+        generateClient: generateClientStub,
       });
 
       const config = { endpoint: '_endpoint', authorization: '_authorization', clientKey: '_clientKey' };
@@ -61,9 +76,9 @@ describe('creatorDataAPI client unit tests', () => {
       const programID = 'programID';
       const program = 'program';
       const Client = { program: { get: sinon.stub().resolves(program) }, prototypeProgram: { get: sinon.stub().resolves(program) } };
-      const VFClient = sinon.stub().returns(Client);
+      const generateClientStub = sinon.stub().returns(Client);
       const VF = sinon.stub().returns({
-        generateClient: VFClient,
+        generateClient: generateClientStub,
       });
 
       const config = { endpoint: '_endpoint', authorization: '_authorization', clientKey: '_clientKey', prototype: false };
@@ -79,9 +94,9 @@ describe('creatorDataAPI client unit tests', () => {
     const versionID = 'versionID';
     const version = 'version';
     const Client = { version: { get: sinon.stub().resolves(version) } };
-    const VFClient = sinon.stub().returns(Client);
+    const generateClientStub = sinon.stub().returns(Client);
     const VF = sinon.stub().returns({
-      generateClient: VFClient,
+      generateClient: generateClientStub,
     });
 
     const config = { endpoint: '_endpoint', authorization: '_authorization', clientKey: '_clientKey' };
@@ -95,9 +110,9 @@ describe('creatorDataAPI client unit tests', () => {
     const projectID = 'projectID';
     const project = 'project';
     const Client = { project: { get: sinon.stub().resolves(project) } };
-    const VFClient = sinon.stub().returns(Client);
+    const generateClientStub = sinon.stub().returns(Client);
     const VF = sinon.stub().returns({
-      generateClient: VFClient,
+      generateClient: generateClientStub,
     });
 
     const config = { endpoint: '_endpoint', authorization: '_authorization', clientKey: '_clientKey' };

--- a/tests/lib/DataAPI/creatorDataAPI.unit.ts
+++ b/tests/lib/DataAPI/creatorDataAPI.unit.ts
@@ -31,12 +31,12 @@ describe('creatorDataAPI client unit tests', () => {
       generateClient: generateClientStub,
     });
 
-    const config = { endpoint: '_endpoint', authorization: '_authorization', clientKey: '_clientKey', prototype: true };
+    const config = { endpoint: '_endpoint', clientKey: '_clientKey', prototype: true };
 
     const creatorDataAPI = new CreatorDataAPI(config, VF as any);
     creatorDataAPI.updateAuthorization('new auth');
 
-    expect(generateClientStub.firstCall.args).to.eql([{ authorization: config.authorization }]);
+    expect(generateClientStub.firstCall.args).to.eql([{ authorization: '' }]);
     expect(generateClientStub.secondCall.args).to.eql([{ authorization: 'new auth' }]);
   });
 


### PR DESCRIPTION
**Fixes or implements CORE-5221**

### Brief description. What is this change?
Allows for API key support in general-runtime when hitting the interact endpoint.

### Implementation details. How do you make this change?
The initial authorization passed in is from an environment variable. This is stored as the initial authorization key, and all new requests call updateAuthorization(). If that is called with a new authorization string, it is from the request header and is used. If it is called without a new authorization string, the environment variable authorization is set again.

### Related PRs
| branch              | PR          |
| ------------------- | ----------- |
| general-runtime | [link](https://github.com/voiceflow/general-runtime/pull/65) |
| api-sdk     | [link](https://github.com/voiceflow/api-sdk/pull/50) |

### Checklist

- [ ✅  ] title of PR reflects the branch name
- [ ✅  ] all commits adhere to conventional commits
- [ ✅  ] appropriate tests have been written
- [ ✅  ] all the dependencies are upgraded