### PR TITLE
feat: upgrade deps for prototype share password (CORE-5368)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "@types/safe-json-stringify": "^1.1.0",
-    "@voiceflow/api-sdk": "1.28.2",
+    "@voiceflow/api-sdk": "1.29.0",
     "@voiceflow/common": "6.5.0",
-    "@voiceflow/general-types": "1.37.2",
+    "@voiceflow/general-types": "1.40.0",
     "axios": "^0.19.0",
     "bluebird": "^3.7.2",
     "form-data": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -842,6 +842,17 @@
     axios "^0.21.1"
     superstruct "^0.10.12"
 
+"@voiceflow/api-sdk@1.29.0":
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/@voiceflow/api-sdk/-/api-sdk-1.29.0.tgz#8368427f13357507e5009d5b92086264bd890229"
+  integrity sha512-fILQ5XNAEG0FUCr2h9jhAnwC6qeRdFAK7vvZS9x0bCtZIh6GcRsjwJ3F7NqBu7rFImSafhW0vriKn4P3x+vwQQ==
+  dependencies:
+    "@types/atob" "^2.1.2"
+    "@voiceflow/logger" "^1.5.2"
+    atob "^2.1.2"
+    axios "^0.21.1"
+    superstruct "^0.10.12"
+
 "@voiceflow/commitlint-config@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@voiceflow/commitlint-config/-/commitlint-config-1.0.1.tgz#e9513aa348d5e88ff064022e2dae8d0d7e227f6a"
@@ -886,6 +897,13 @@
   integrity sha512-BKthZNP7MzNNeP0Sm3jX4QsjmoUGIJ2LY54/lz1wPB7rD9KVKX/YgeFPHAnZv6DAH209VU/wDR++STZh68DxmA==
   dependencies:
     "@voiceflow/api-sdk" "1.28.2"
+
+"@voiceflow/general-types@1.40.0":
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.40.0.tgz#a9433eee6a92474b2cc1c97dd59968f58615c8f2"
+  integrity sha512-qX/jmUJT+hJhfK0AC+bxKjosrl/xAY/+WQwtq8SIl7BAh8WspgnKbDvUyoUV+xQUB0XplTQkI4st5IIq7PVgZw==
+  dependencies:
+    "@voiceflow/api-sdk" "1.29.0"
 
 "@voiceflow/git-branch-check@^1.1.3":
   version "1.1.3"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-5368**

### Brief description. What is this change?

Upgrading dependencies for prototype share view password

### Implementation details. How do you make this change?

`yarn upgrade @voiceflow/api-sdk@1.29.0 @voiceflow/general-types/@1.40.0`

### Setup information

None

### Deployment Notes

None

### Related PRs

<!-- List related PRs against other branches -->

Upgraded dependencies

| branch              | PR          |
| ------------------- | ----------- |
| `api-sdk` | [link](https://github.com/voiceflow/api-sdk/pull/56) |
| `general-types` | [link](https://github.com/voiceflow/general-types/pull/68) |

Related branches

| branch              | PR          |
| ------------------- | ----------- |

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- ~~[ ] appropriate tests have been written~~
- [x] all the dependencies are upgraded